### PR TITLE
Re-Enable build

### DIFF
--- a/.github/workflows/dotnet-main.yml
+++ b/.github/workflows/dotnet-main.yml
@@ -33,7 +33,10 @@ jobs:
     - name: format
       run: dotnet format --verify-no-changes --no-restore
 
-    - name: build & test & cover
+    - name: build
+      run: dotnet build -c Release
+
+    - name: test & cover
       run: dotnet test --collect "Code Coverage;Format=Xml;CoverageFileName=coverage.xml" --results-directory "./test-results" --no-restore --nologo -c Release --logger trx
 
     - name: publish test results

--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -33,7 +33,10 @@ jobs:
     - name: format
       run: dotnet format --verify-no-changes --no-restore
 
-    - name: build & test & cover
+    - name: build
+      run: dotnet build -c Release
+
+    - name: test & cover
       run: dotnet test --collect "Code Coverage;Format=Xml;CoverageFileName=coverage.xml" --results-directory "./test-results" --no-restore --nologo -c Release --logger trx
 
     - name: publish test results

--- a/PiBox.Plugins/Persistence/EntityFramework/src/PiBox.Plugins.Persistence.EntityFramework/PiBox.Plugins.Persistence.EntityFramework.csproj
+++ b/PiBox.Plugins/Persistence/EntityFramework/src/PiBox.Plugins.Persistence.EntityFramework/PiBox.Plugins.Persistence.EntityFramework.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Because the Hosting-Project is not built during testing (no test project), we need to build first, so the pack command won't fail (because of --no-build).