### PR TITLE
Allow YAML Deserialize Extension to ignore unmatched properties

### DIFF
--- a/PiBox.Hosting/Abstractions/src/PiBox.Hosting.Abstractions/Extensions/SerializationExtensions.cs
+++ b/PiBox.Hosting/Abstractions/src/PiBox.Hosting.Abstractions/Extensions/SerializationExtensions.cs
@@ -25,6 +25,7 @@ namespace PiBox.Hosting.Abstractions.Extensions
 
         private static readonly IDeserializer _deserializer = new DeserializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
             .WithDuplicateKeyChecking()
             .WithTypeConverter(new ValueObjectYamlTypeConverter())
             .Build();

--- a/PiBox.Hosting/Abstractions/test/PiBox.Hosting.Abstractions.Tests/Extensions/SerializationExtensionTests.cs
+++ b/PiBox.Hosting/Abstractions/test/PiBox.Hosting.Abstractions.Tests/Extensions/SerializationExtensionTests.cs
@@ -32,9 +32,12 @@ namespace PiBox.Hosting.Abstractions.Tests.Extensions
         {
             var sample = new Sample { HealthCheckTag = HealthCheckTag.Liveness, Name = "test" };
             var serialized = sample.Serialize(SerializationMethod.Yaml);
+            var withSchema = "$schema: bla.json" + Environment.NewLine + serialized;
             var deserialized = serialized.Deserialize<Sample>(SerializationMethod.Yaml);
+            var deserializedWithSchema = withSchema.Deserialize<Sample>(SerializationMethod.Yaml);
 
             deserialized.Should().BeEquivalentTo(sample);
+            deserializedWithSchema.Should().BeEquivalentTo(sample);
 
             var obj = serialized.Deserialize(typeof(Sample), SerializationMethod.Yaml);
             obj.Should().BeOfType<Sample>();


### PR DESCRIPTION
This change will allow to ignore unmatched properties to be ignored on the deserializtion.