### PR TITLE
Sanity cors expose headers too

### DIFF
--- a/PiBox.Hosting/WebHost/src/PiBox.Hosting.WebHost/Extensions/CorsPolicyExtensions.cs
+++ b/PiBox.Hosting/WebHost/src/PiBox.Hosting.WebHost/Extensions/CorsPolicyExtensions.cs
@@ -12,6 +12,8 @@ namespace PiBox.Hosting.WebHost.Extensions
                 corsPolicy.Methods.Add("*");
             if (!corsPolicy.Origins.Any())
                 corsPolicy.Origins.Add("*");
+            if (!corsPolicy.ExposedHeaders.Any())
+                corsPolicy.ExposedHeaders.Add("*");
         }
     }
 }

--- a/PiBox.Hosting/WebHost/test/PiBox.Hosting.WebHost.Tests/CorsPolicyExtensionTests.cs
+++ b/PiBox.Hosting/WebHost/test/PiBox.Hosting.WebHost.Tests/CorsPolicyExtensionTests.cs
@@ -10,18 +10,21 @@ namespace PiBox.Hosting.WebHost.Tests
         [Test]
         public void SetSanityDefaults()
         {
-            CorsPolicy corsPolicy = new CorsPolicy();
+            var corsPolicy = new CorsPolicy();
             corsPolicy.Origins.Any().Should().BeFalse();
             corsPolicy.AllowAnyOrigin.Should().BeFalse();
             corsPolicy.Headers.Any().Should().BeFalse();
             corsPolicy.AllowAnyHeader.Should().BeFalse();
             corsPolicy.Methods.Any().Should().BeFalse();
             corsPolicy.AllowAnyMethod.Should().BeFalse();
+            corsPolicy.ExposedHeaders.Should().HaveCount(0);
 
             corsPolicy.SetSanityDefaults();
             corsPolicy.AllowAnyOrigin.Should().BeTrue();
             corsPolicy.AllowAnyHeader.Should().BeTrue();
             corsPolicy.AllowAnyMethod.Should().BeTrue();
+            corsPolicy.ExposedHeaders.Should().HaveCount(1);
+            corsPolicy.ExposedHeaders.Should().Contain("*");
         }
     }
 }


### PR DESCRIPTION
Can be configured, but has no default to star like the others.
Which this defaulted as star, we will get content disposition, ... too.