### PR TITLE
Feature/healthchecks

### DIFF
--- a/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPlugin.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPlugin.cs
@@ -59,7 +59,10 @@ namespace PiBox.Plugins.Authorization.Keycloak
 
         public void ConfigureHealthChecks(IHealthChecksBuilder healthChecksBuilder)
         {
-            var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetAuthority()) { Path = $"{_keycloakPluginConfiguration.Realms.Prefix.TrimEnd('/')}/master" };
+            var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetHelthUri())
+            {
+                Path = $"{_keycloakPluginConfiguration.Realms.Prefix.TrimEnd('/')}/{_keycloakPluginConfiguration.Realms.Default}"
+            };
             var uri = uriBuilder.Uri;
             healthChecksBuilder.AddUrlGroup(uri, "keycloak", HealthStatus.Unhealthy, new[] { HealthCheckTag.Readiness.Value });
         }

--- a/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPlugin.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPlugin.cs
@@ -59,10 +59,8 @@ namespace PiBox.Plugins.Authorization.Keycloak
 
         public void ConfigureHealthChecks(IHealthChecksBuilder healthChecksBuilder)
         {
-            var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetHelthUri())
-            {
-                Path = $"{_keycloakPluginConfiguration.Realms.Prefix.TrimEnd('/')}/{_keycloakPluginConfiguration.Realms.Default}"
-            };
+            var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetHealthCheck()) { Path = _keycloakPluginConfiguration.HealthCheckConfig.Prefix };
+            //var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetAuthority()) { Path = $"{_keycloakPluginConfiguration.Realms.Prefix.TrimEnd('/')}/master" };
             var uri = uriBuilder.Uri;
             healthChecksBuilder.AddUrlGroup(uri, "keycloak", HealthStatus.Unhealthy, new[] { HealthCheckTag.Readiness.Value });
         }

--- a/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPlugin.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPlugin.cs
@@ -60,7 +60,6 @@ namespace PiBox.Plugins.Authorization.Keycloak
         public void ConfigureHealthChecks(IHealthChecksBuilder healthChecksBuilder)
         {
             var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetHealthCheck()) { Path = _keycloakPluginConfiguration.HealthCheckConfig.Prefix };
-            //var uriBuilder = new UriBuilder(_keycloakPluginConfiguration.GetAuthority()) { Path = $"{_keycloakPluginConfiguration.Realms.Prefix.TrimEnd('/')}/master" };
             var uri = uriBuilder.Uri;
             healthChecksBuilder.AddUrlGroup(uri, "keycloak", HealthStatus.Unhealthy, new[] { HealthCheckTag.Readiness.Value });
         }

--- a/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPluginConfiguration.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPluginConfiguration.cs
@@ -43,7 +43,7 @@ namespace PiBox.Plugins.Authorization.Keycloak
 
     public class HealthCheckConfig
     {
-        public string Host { get; set; }
+        public string Host { get; set; } = "example.com";
         public int? Port { get; set; } = 9000;
         public string Prefix { get; set; } = "/health/ready";
     }

--- a/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPluginConfiguration.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/src/PiBox.Plugins.Authorization.Keycloak/KeycloakPluginConfiguration.cs
@@ -10,6 +10,7 @@ namespace PiBox.Plugins.Authorization.Keycloak
         public bool Enabled { get; set; }
         public string Host { get; set; }
         public int? Port { get; set; }
+        public int? HealthPort { get; set; }
         public bool Insecure { get; set; }
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
@@ -22,6 +23,14 @@ namespace PiBox.Plugins.Authorization.Keycloak
             var httpScheme = (Insecure ? HttpScheme.Http : HttpScheme.Https).ToString();
             return Port.HasValue
                 ? new UriBuilder(httpScheme, Host, Port.Value).Uri
+                : new UriBuilder(httpScheme, Host).Uri;
+        }
+        public Uri GetHelthUri()
+        {
+            if (string.IsNullOrEmpty(Host)) throw new ArgumentException("Keycloak.Host was not specified but authentication is enabled!");
+            var httpScheme = (Insecure ? HttpScheme.Http : HttpScheme.Https).ToString();
+            return HealthPort.HasValue
+                ? new UriBuilder(httpScheme, Host, HealthPort.Value).Uri
                 : new UriBuilder(httpScheme, Host).Uri;
         }
     }

--- a/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/KeycloakPluginTests.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/KeycloakPluginTests.cs
@@ -14,7 +14,6 @@ using NSubstitute;
 using NSubstitute.Core;
 using NUnit.Framework;
 using PiBox.Hosting.Abstractions;
-using PiBox.Hosting.Abstractions.Attributes;
 using PiBox.Plugins.Authorization.Keycloak.Scheme;
 using PiBox.Testing.Extensions;
 
@@ -62,8 +61,6 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
             httpClient.BaseAddress!.Scheme.Should().Be("https");
             httpClient.BaseAddress!.Host.Should().Be("example.com");
             httpClient.BaseAddress!.Port.Should().Be(8080);
-
-
 
         }
 
@@ -134,7 +131,9 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 Port = 8080,
                 HealthCheckConfig = new HealthCheckConfig
                 {
-                Host = "example.com", Port = 9100, Prefix = "/health/ready"
+                    Host = "example.com",
+                    Port = 9100,
+                    Prefix = "/health/ready"
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheckConfig.Prefix };
@@ -164,7 +163,9 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 Port = 8080,
                 HealthCheckConfig = new HealthCheckConfig
                 {
-                    Host = "health.com", Port = 9999, Prefix = "/something/notready"
+                    Host = "health.com",
+                    Port = 9999,
+                    Prefix = "/something/notready"
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheckConfig.Prefix };

--- a/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/KeycloakPluginTests.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/KeycloakPluginTests.cs
@@ -14,6 +14,7 @@ using NSubstitute;
 using NSubstitute.Core;
 using NUnit.Framework;
 using PiBox.Hosting.Abstractions;
+using PiBox.Hosting.Abstractions.Attributes;
 using PiBox.Plugins.Authorization.Keycloak.Scheme;
 using PiBox.Testing.Extensions;
 
@@ -61,6 +62,9 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
             httpClient.BaseAddress!.Scheme.Should().Be("https");
             httpClient.BaseAddress!.Host.Should().Be("example.com");
             httpClient.BaseAddress!.Port.Should().Be(8080);
+          
+            
+
         }
 
         [Test]
@@ -118,6 +122,25 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
             if (registeredMiddleware.BaseType == typeof(TMiddleware))
                 return;
             registeredMiddleware.Should().Be(typeof(TMiddleware));
+        }
+        [Test]
+        public void ConfigureHealtChecks_Use9000ForHealth()
+        {
+            var hcBuilder = Substitute.For<IHealthChecksBuilder>();
+            var serviceCollection = new ServiceCollection();
+
+            hcBuilder.Services.Returns(serviceCollection);
+
+            var config = new KeycloakPluginConfiguration
+            {
+                Enabled = true,
+                Host = "example.com",
+                Insecure = false,
+                Port = 8080,
+            };
+
+            var plugin = GetPlugin(config);
+
         }
     }
 }


### PR DESCRIPTION
This is part of the Keycloak integration. Previously, the Keycloak port and health checks port were the same by default. However, with the recent update, it is now possible to configure these separately via the appsettings.yaml file. Additionally, the HealthCheckConfig allows customization of the health checks Host, Port, and Prefix, providing more flexibility for defining the health check endpoints independently from the Keycloak authentication configuration.