### PR TITLE
fix policy require role

### DIFF
--- a/PiBox.Plugins/Authorization/Abstractions/src/PiBox.Plugins.Authorization.Abstractions/PolicyExtensions.cs
+++ b/PiBox.Plugins/Authorization/Abstractions/src/PiBox.Plugins.Authorization.Abstractions/PolicyExtensions.cs
@@ -24,10 +24,7 @@ namespace PiBox.Plugins.Authorization.Abstractions
             {
                 options.AddPolicy(authPolicy.Name!, builder =>
                 {
-                    foreach (var authPolicyRole in authPolicy.Roles!)
-                    {
-                        builder.RequireRole(authPolicyRole);
-                    }
+                    builder.RequireRole(authPolicy.Roles!);
                 });
             }
         }


### PR DESCRIPTION
Policy roles need to be added to a single RolesAuthorizationRequirement, not seprate RolesAuthorizationRequirement. Otherwise all roles need to be existent within the identity.