### PR TITLE
Feature/hangfire remove default storages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,6 @@
     </PackageVersion>
     <PackageVersion Version="1.8.10" Include="HangFire" />
     <PackageVersion Version="1.8.0" Include="Hangfire.MemoryStorage" />
-    <PackageVersion Version="1.20.5" Include="Hangfire.PostgreSql" />
     <PackageVersion Version="2.5.0" Include="KafkaFlow" />
     <PackageVersion Version="2.5.0" Include="KafkaFlow.Extensions.Hosting" />
     <PackageVersion Version="2.5.0" Include="KafkaFlow.LogHandler.Microsoft" />

--- a/PiBox.Plugins/Jobs/Hangfire/README.md
+++ b/PiBox.Plugins/Jobs/Hangfire/README.md
@@ -83,8 +83,6 @@ public class TestHangfireConfigurator : IHangfireConfigurator
     }
 
     public void ConfigureServer(BackgroundJobServerOptions options) {}
-
-    public bool IncludesStorage { get; }
 }
 ```
 

--- a/PiBox.Plugins/Jobs/Hangfire/README.md
+++ b/PiBox.Plugins/Jobs/Hangfire/README.md
@@ -26,15 +26,8 @@ For example
 
 ```yaml
 hangfire:
-  Host: localhost
-  Port: 5432
-  Database: postgres
-  User: postgres
-  Password: postgres
-  InMemory: true
   enableJobsByFeatureManagementConfig: false
   allowedDashboardHost: localhost # you need to set this configuration to be able to access the dashboard from the specified host
-  invisibilityTimeoutInMinutes: 30
 
 featureManagement: # we can conveniently can use the microsoft feature management system to enable jobs based on configuration
   hangfireTestJob: true # if you have enabled the 'enableJobsByFeatureManagementConfig: true' then you can configure here if your jobs should run on execution or not, useful for multiple environments etc.
@@ -46,18 +39,10 @@ HangfireConfiguration.cs
 [Configuration("hangfire")]
 public class HangfireConfiguration
 {
-    public string? Host { get; set; }
-    public int Port { get; set; }
-    public string? Database { get; set; }
-    public string? User { get; set; }
-    public string? Password { get; set; }
-    public bool InMemory { get; set; }
     public string AllowedDashboardHost { get; set; }
     public bool EnableJobsByFeatureManagementConfig { get; set; }
     public int? PollingIntervalInMs { get; set; }
     public int? WorkerCount { get; set; }
-    public int InvisibilityTimeoutInMinutes { get; set; } = 30;
-    public string ConnectionString => $"Host={Host};Port={Port};Database={Database};Username={User};Password={Password};";
 }
 ```
 
@@ -74,6 +59,51 @@ public class SamplePluginHost : IPluginServiceConfiguration
                 jobRegister.RegisterParameterizedRecurringAsyncJob<HangfireParameterizedTestJob, int>(Cron.Daily(), 1); // every day at 0:00 UTC
                 jobRegister.RegisterRecurringAsyncJob<HangfireTestJob>(Cron.Hourly(15)); // every hour to minute 15 UTC
             });
+    }
+}
+```
+
+### Configuring Job Storage for Hangfire
+
+The Hangfire plugin does not automatically register a storage for jobs. This is done on the implementing service's side by using the HangfireConfigurator logic that allows configuring Hangfire with a custom Configurator class in the implementing project.
+
+```csharp
+public class TestHangfireConfigurator : IHangfireConfigurator
+{
+    public void Configure(IGlobalConfiguration config)
+    {
+        var connectionString = "testConnection";
+        config.UsePostgreSqlStorage(opts => opts.UseNpgsqlConnection(connectionString),
+            new PostgreSqlStorageOptions
+            {
+                InvisibilityTimeout = TimeSpan.FromMinutes(180) // controls the timeout until a second job is started when an existing job
+                                                                // is running for longer than the specified minutes
+                                                                // option not necessary for sql server storage
+            });
+    }
+
+    public void ConfigureServer(BackgroundJobServerOptions options) {}
+
+    public bool IncludesStorage { get; }
+}
+```
+
+This is then applied with the following logic in the HangfirePlugin:
+
+```csharp
+public class HangFirePlugin(HangfireConfiguration configuration, IImplementationResolver implementationResolver, IHangfireConfigurator[] configurators)
+        : IPluginServiceConfiguration, IPluginApplicationConfiguration, IPluginHealthChecksConfiguration
+{
+    public void ConfigureServices(IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddFeatureManagement();
+        serviceCollection.AddHangfire(conf =>
+            {
+                conf.UseSerializerSettings(new JsonSerializerSettings());
+                conf.UseSimpleAssemblyNameTypeSerializer();
+                configurators.ForEach(x => x.Configure(conf));
+            }
+        );
     }
 }
 ```

--- a/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/HangFirePlugin.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/HangFirePlugin.cs
@@ -1,7 +1,5 @@
 using Hangfire;
 using Hangfire.Dashboard;
-using Hangfire.MemoryStorage;
-using Hangfire.PostgreSql;
 using Hangfire.States;
 using Hangfire.Storage;
 using Microsoft.AspNetCore.Builder;
@@ -10,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
 using Newtonsoft.Json;
 using PiBox.Hosting.Abstractions;
-using PiBox.Hosting.Abstractions.Exceptions;
 using PiBox.Hosting.Abstractions.Extensions;
 using PiBox.Hosting.Abstractions.Plugins;
 using PiBox.Hosting.Abstractions.Services;

--- a/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/HangfireConfiguration.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/HangfireConfiguration.cs
@@ -6,18 +6,10 @@ namespace PiBox.Plugins.Jobs.Hangfire
     [Configuration("hangfire")]
     public class HangfireConfiguration
     {
-        public string Host { get; set; }
-        public int Port { get; set; }
-        public string Database { get; set; }
-        public string User { get; set; }
-        public string Password { get; set; }
-        public bool InMemory { get; set; }
         public string AllowedDashboardHost { get; set; }
         public bool EnableJobsByFeatureManagementConfig { get; set; }
         public int? PollingIntervalInMs { get; set; }
         public int? WorkerCount { get; set; }
         public string[] Queues { get; set; } = [EnqueuedState.DefaultQueue];
-        public int InvisibilityTimeoutInMinutes { get; set; } = 30;
-        public string ConnectionString => $"Host={Host};Port={Port};Database={Database};Username={User};Password={Password};";
     }
 }

--- a/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/IHangfireConfigurator.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/IHangfireConfigurator.cs
@@ -5,7 +5,6 @@ namespace PiBox.Plugins.Jobs.Hangfire
 {
     public interface IHangfireConfigurator : IPluginConfigurator
     {
-        public bool IncludesStorage { get; }
         void Configure(IGlobalConfiguration config);
         void ConfigureServer(BackgroundJobServerOptions options);
     }

--- a/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/PiBox.Plugins.Jobs.Hangfire.csproj
+++ b/PiBox.Plugins/Jobs/Hangfire/src/PiBox.Plugins.Jobs.Hangfire/PiBox.Plugins.Jobs.Hangfire.csproj
@@ -12,8 +12,6 @@
     <ItemGroup>
       <PackageReference Include="AspNetCore.HealthChecks.Hangfire" />
       <PackageReference Include="HangFire" />
-      <PackageReference Include="Hangfire.MemoryStorage" />
-      <PackageReference Include="Hangfire.PostgreSql" />
       <PackageReference Include="Microsoft.FeatureManagement" />
       <PackageReference Include="Newtonsoft.Json" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/HangfireConfigurationTests.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/HangfireConfigurationTests.cs
@@ -10,18 +10,10 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
         {
             var config = HangfirePluginTests.HangfireConfiguration;
 
-            config.ConnectionString.Should()
-                .Be("Host=testHost;Port=9999;Database=testDatabase;Username=testUser;Password=testPassword;");
-            config.Host.Should().Be("testHost");
-            config.Port.Should().Be(9999);
-            config.Database.Should().Be("testDatabase");
-            config.InMemory.Should().Be(true);
             config.EnableJobsByFeatureManagementConfig.Should().Be(true);
             config.WorkerCount.Should().Be(200);
             config.AllowedDashboardHost.Should().Be("localhost");
             config.PollingIntervalInMs.Should().Be(1000);
-            config.User.Should().Be("testUser");
-            config.Password.Should().Be("testPassword");
         }
     }
 }

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/HangfirePluginTests.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/HangfirePluginTests.cs
@@ -110,7 +110,6 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
             options.Should().NotBeNull();
             options.SchedulePollingInterval.Should().Be(TimeSpan.FromMilliseconds(HangfireConfiguration.PollingIntervalInMs!.Value));
             options.WorkerCount.Should().Be(HangfireConfiguration.WorkerCount!.Value);
-
         }
     }
 }

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/HangfirePluginTests.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/HangfirePluginTests.cs
@@ -22,16 +22,10 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
     {
         internal static readonly HangfireConfiguration HangfireConfiguration = new()
         {
-            Database = "testDatabase",
-            Host = "testHost",
-            Port = 9999,
-            Password = "testPassword",
             AllowedDashboardHost = "localhost",
-            InMemory = true,
             PollingIntervalInMs = 1000,
             WorkerCount = 200,
             EnableJobsByFeatureManagementConfig = true,
-            User = "testUser",
             Queues = ["default", "test"]
         };
 

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/PiBox.Plugins.Jobs.Hangfire.Tests.csproj
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/PiBox.Plugins.Jobs.Hangfire.Tests.csproj
@@ -11,4 +11,8 @@
       <ProjectReference Include="..\..\src\PiBox.Plugins.Jobs.Hangfire\PiBox.Plugins.Jobs.Hangfire.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Hangfire.MemoryStorage" />
+    </ItemGroup>
+
 </Project>

--- a/example/src/PiBox.Example.Service/TestHangfire.cs
+++ b/example/src/PiBox.Example.Service/TestHangfire.cs
@@ -7,8 +7,6 @@ namespace PiBox.Example.Service
 {
     public class TestHangfire : IHangfireConfigurator
     {
-        public bool IncludesStorage => false;
-
         public void Configure(IGlobalConfiguration config)
         { }
 

--- a/example/src/PiBox.Example.Service/TestHangfire.cs
+++ b/example/src/PiBox.Example.Service/TestHangfire.cs
@@ -1,5 +1,4 @@
 using Hangfire;
-using Hangfire.MemoryStorage;
 using PiBox.Plugins.Jobs.Hangfire;
 using PiBox.Plugins.Jobs.Hangfire.Attributes;
 using PiBox.Plugins.Jobs.Hangfire.Job;
@@ -11,9 +10,7 @@ namespace PiBox.Example.Service
         public bool IncludesStorage => false;
 
         public void Configure(IGlobalConfiguration config)
-        {
-            config.UseMemoryStorage();
-        }
+        { }
 
         public void ConfigureServer(BackgroundJobServerOptions options)
         {


### PR DESCRIPTION
Removes default storage configuration from hangfire plugin. Storage configuration is now part of the implementing service's configuration so we don't have to maintain storage connections/compatibility. 