### PR TITLE
Remove FluentAssertions dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,12 +73,12 @@
     <PackageVersion Version="1.6.4" Include="Restease" />
     <PackageVersion Version="2.4.1" Include="NaughtyStrings.Bogus" />
     <PackageVersion Version="35.4.0" Include="Bogus" />
-    <PackageVersion Version="7.1.0" Include="FluentAssertions" />
     <PackageVersion Version="17.12.0" Include="Microsoft.NET.Test.Sdk" />
     <PackageVersion Version="4.6.0" Include="NUnit3TestAdapter" />
     <PackageVersion Version="5.3.0" Include="NSubstitute" />
     <PackageVersion Version="1.0.17" Include="NSubstitute.Analyzers.CSharp" />
-    <PackageVersion Version="3.14.0" Include="NUnit" />
+    <PackageVersion Version="4.3.2" Include="NUnit" />
+    <PackageVersion Version="4.6.0" Include="NUnit.Analyzers" />
     <PackageVersion Version="2.12.1" Include="Allure.NUnit" />
     <PackageVersion Version="4.1.15" Include="Unleash.Client" />
     <PackageVersion Version="6.0.0" Include="Vogen" />

--- a/PiBox.Hosting/Abstractions/test/PiBox.Hosting.Abstractions.Tests/Extensions/SerializationExtensionTests.cs
+++ b/PiBox.Hosting/Abstractions/test/PiBox.Hosting.Abstractions.Tests/Extensions/SerializationExtensionTests.cs
@@ -6,11 +6,19 @@ namespace PiBox.Hosting.Abstractions.Tests.Extensions
 {
     public class SerializationExtensionTests
     {
-        private class Sample
+        private class Sample : IEquatable<Sample>
         {
             // vogen type...
             public HealthCheckTag HealthCheckTag { get; set; }
             public string Name { get; set; }
+
+            // IEquatable
+            public bool Equals(Sample other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return HealthCheckTag.Equals(other.HealthCheckTag) && Name == other.Name;
+            }
         }
 
         [Test]
@@ -20,11 +28,11 @@ namespace PiBox.Hosting.Abstractions.Tests.Extensions
             var serialized = sample.Serialize();
             var deserialized = serialized.Deserialize<Sample>();
 
-            deserialized.Should().BeEquivalentTo(sample);
+            Assert.That(deserialized, Is.EqualTo(sample));
 
             var obj = serialized.Deserialize(typeof(Sample));
             obj.Should().BeOfType<Sample>();
-            (obj as Sample).Should().BeEquivalentTo(sample);
+            Assert.That((obj as Sample), Is.EqualTo(sample));
         }
 
         [Test]
@@ -36,12 +44,12 @@ namespace PiBox.Hosting.Abstractions.Tests.Extensions
             var deserialized = serialized.Deserialize<Sample>(SerializationMethod.Yaml);
             var deserializedWithSchema = withSchema.Deserialize<Sample>(SerializationMethod.Yaml);
 
-            deserialized.Should().BeEquivalentTo(sample);
-            deserializedWithSchema.Should().BeEquivalentTo(sample);
+            Assert.That(deserialized, Is.EqualTo(sample));
+            Assert.That(deserializedWithSchema, Is.EqualTo(sample));
 
             var obj = serialized.Deserialize(typeof(Sample), SerializationMethod.Yaml);
             obj.Should().BeOfType<Sample>();
-            (obj as Sample).Should().BeEquivalentTo(sample);
+            Assert.That(obj as Sample, Is.EqualTo(sample));
         }
     }
 }

--- a/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/KeycloakPluginTests.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/KeycloakPluginTests.cs
@@ -69,8 +69,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
             var config = new KeycloakPluginConfiguration { Enabled = true };
             var sc = new ServiceCollection();
             var configureCall = () => GetPlugin(config).ConfigureServices(sc);
-            configureCall.Should().Throw<ArgumentException>()
-                .WithMessage("Keycloak.Host was not specified but authentication is enabled!");
+            configureCall.Should().Throw<ArgumentException>("Keycloak.Host was not specified but authentication is enabled!");
         }
 
         [Test]
@@ -127,7 +126,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheck.Prefix };
-            uriBuilder.Uri.Should().Be("http://example.com:9000/health/ready");
+            uriBuilder.Uri.Should().Be(new Uri("http://example.com:9000/health/ready"));
         }
 
         [Test]
@@ -147,7 +146,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheck.Prefix };
-            uriBuilder.Uri.Should().Be("http://example.com:9000/health/ready");
+            uriBuilder.Uri.Should().Be(new Uri("http://example.com:9000/health/ready"));
         }
 
         [Test]
@@ -168,7 +167,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheck.Prefix };
-            uriBuilder.Uri.Should().Be("https://example.com:9000/health/ready");
+            uriBuilder.Uri.Should().Be(new Uri("https://example.com:9000/health/ready"));
         }
 
         [Test]
@@ -187,7 +186,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
             };
 
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheck.Prefix };
-            uriBuilder.Uri.Should().Be("http://example.com:9000/health/ready");
+            uriBuilder.Uri.Should().Be(new Uri("http://example.com:9000/health/ready"));
         }
 
         [Test]
@@ -207,7 +206,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheck.Prefix };
-            uriBuilder.Uri.Should().Be("http://health.com:9999/something/notready");
+            uriBuilder.Uri.Should().Be(new Uri("http://health.com:9999/something/notready"));
         }
 
         [Test]
@@ -227,7 +226,7 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests
                 }
             };
             var uriBuilder = new UriBuilder(config.GetHealthCheck()) { Path = config.HealthCheck.Prefix };
-            uriBuilder.Uri.Should().Be("http://example.com:9999/something/notready");
+            uriBuilder.Uri.Should().Be(new Uri("http://example.com:9999/something/notready"));
         }
 
         private static void AssertMiddleware<TMiddleware>(ICall call)

--- a/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/Scheme/KeycloakAuthenticationHandlerTests.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/Scheme/KeycloakAuthenticationHandlerTests.cs
@@ -37,6 +37,12 @@ namespace PiBox.Plugins.Authorization.Keycloak.Tests.Scheme
             ActivityTestBootstrapper.Setup();
         }
 
+        [OneTimeTearDown]
+        public void Teardown()
+        {
+            _privateKey.Dispose();
+        }
+
         private async Task<KeycloakAuthenticationHandler> GetHandler(HttpContext context)
         {
             _authSchemeOptions.Get(KeycloakDefaults.Scheme).Returns(new AuthenticationSchemeOptions());

--- a/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/Scheme/PublicKeyServiceTests.cs
+++ b/PiBox.Plugins/Authorization/Keycloak/test/PiBox.Plugins.Authorization.Keycloak.Tests/Scheme/PublicKeyServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Security.Cryptography;
 using FluentAssertions;
@@ -13,6 +14,7 @@ using RichardSzalay.MockHttp;
 
 namespace PiBox.Plugins.Authorization.Keycloak.Tests.Scheme
 {
+    [SuppressMessage("Structure", "NUnit1032:An IDisposable field/property should be Disposed in a TearDown method")]
     public class PublicKeyServiceTests
     {
         private readonly IMemoryCache _cache = Substitute.For<IMemoryCache>();

--- a/PiBox.Plugins/Handlers/Cqrs/test/PiBox.Plugins.Handlers.Cqrs.Tests/GuidIdentifierTests.cs
+++ b/PiBox.Plugins/Handlers/Cqrs/test/PiBox.Plugins.Handlers.Cqrs.Tests/GuidIdentifierTests.cs
@@ -15,7 +15,7 @@ namespace PiBox.Plugins.Handlers.Cqrs.Tests
         [Test]
         public void GuidIdentifierParseShouldBeWorking()
         {
-            GuidIdentifier.Parse("05a82a17-5a7f-4f28-8ff9-37f35c2cfb5f").Id.Should().Be("05a82a17-5a7f-4f28-8ff9-37f35c2cfb5f");
+            GuidIdentifier.Parse("05a82a17-5a7f-4f28-8ff9-37f35c2cfb5f").Id.Should().Be(Guid.Parse("05a82a17-5a7f-4f28-8ff9-37f35c2cfb5f"));
         }
 
         [Test]

--- a/PiBox.Plugins/Handlers/Cqrs/test/PiBox.Plugins.Handlers.Cqrs.Tests/SimpleResource/Validators/ValidationExtensionsTests.cs
+++ b/PiBox.Plugins/Handlers/Cqrs/test/PiBox.Plugins.Handlers.Cqrs.Tests/SimpleResource/Validators/ValidationExtensionsTests.cs
@@ -19,10 +19,10 @@ namespace PiBox.Plugins.Handlers.Cqrs.Tests.SimpleResource.Validators
             var validationException = await _validator
                 .Invoking(async x => await x.ValidateOrThrowAsync(null, CancellationToken.None)).Should()
                 .ThrowAsync<ValidationPiBoxException>();
-            validationException.And.Message.Should().Be(DefaultUserMessage);
-            validationException.And.ValidationErrors.Should().HaveCount(1);
-            validationException.And.ValidationErrors[0].Field.Should().Be("request");
-            validationException.And.ValidationErrors[0].ValidationMessage.Should().Be("Cannot pass null value");
+            validationException.Message.Should().Be(DefaultUserMessage);
+            validationException.ValidationErrors.Should().HaveCount(1);
+            validationException.ValidationErrors[0].Field.Should().Be("request");
+            validationException.ValidationErrors[0].ValidationMessage.Should().Be("Cannot pass null value");
         }
 
         [Test]
@@ -37,10 +37,10 @@ namespace PiBox.Plugins.Handlers.Cqrs.Tests.SimpleResource.Validators
             var validationException = await _validator.Invoking(async x =>
                     await x.ValidateOrThrowAsync(new PagingRequest(0), CancellationToken.None))
                 .Should().ThrowAsync<ValidationPiBoxException>();
-            validationException.And.Message.Should().Be(DefaultUserMessage);
-            validationException.And.ValidationErrors.Should().HaveCount(1);
-            validationException.And.ValidationErrors[0].Field.Should().Be("Size");
-            validationException.And.ValidationErrors[0].ValidationMessage.Should().Be("'Size' must be greater than '0'.");
+            validationException.Message.Should().Be(DefaultUserMessage);
+            validationException.ValidationErrors.Should().HaveCount(1);
+            validationException.ValidationErrors[0].Field.Should().Be("Size");
+            validationException.ValidationErrors[0].ValidationMessage.Should().Be("'Size' must be greater than '0'.");
         }
 
     }

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/JobManagerTests.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/JobManagerTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Hangfire;
 using Hangfire.Common;
@@ -13,6 +13,7 @@ using PiBox.Plugins.Jobs.Hangfire.Job;
 
 namespace PiBox.Plugins.Jobs.Hangfire.Tests
 {
+    [SuppressMessage("Structure", "NUnit1032:An IDisposable field/property should be Disposed in a TearDown method")]
     public class JobManagerTests
     {
         private static readonly global::Hangfire.Common.Job _testJob = new(typeof(TestJob), typeof(TestJob).GetMethod("ExecuteAsync"), new List<object> { CancellationToken.None });
@@ -37,7 +38,8 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
         {
             _monitoringApi.Queues().Returns([new QueueWithTopEnqueuedJobsDto { Name = "test" }]);
             var result = GetJobManager().GetQueues();
-            result.Should().HaveCount(1).And.Contain("test");
+            result.Should().HaveCount(1);
+            result.Should().Contain("test");
         }
 
         [Test]
@@ -52,12 +54,15 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
                     { "Job", new { t = TypeHelper.CurrentTypeSerializer(typeof(TestJob)), m = nameof(TestJob.ExecuteAsync), p = new List<string> {TypeHelper.CurrentTypeSerializer(typeof(CancellationToken))}, a = new string[] {null} }.Serialize() }
                 });
             var result = GetJobManager().GetRecurringJobs();
-            result.Should().HaveCount(1).And.Contain(x => x.Id == "test");
+            result.Should().HaveCount(1);
+            result.Should().Contain(x => x.Id == "test");
 
             result = GetJobManager().GetRecurringJobs<TestJob>();
-            result.Should().HaveCount(1).And.Contain(x => x.Id == "test");
+            result.Should().HaveCount(1);
+            result.Should().Contain(x => x.Id == "test");
             result = GetJobManager().GetRecurringJobs<TestJob>(x => x.Id == "test");
-            result.Should().HaveCount(1).And.Contain(x => x.Id == "test");
+            result.Should().HaveCount(1);
+            result.Should().Contain(x => x.Id == "test");
             result = GetJobManager().GetRecurringJobs<TestJob>(x => x.Id != "test");
             result.Should().HaveCount(0);
         }
@@ -72,13 +77,16 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
                     new("test1", dto)
                 }));
             var result = GetJobManager().GetEnqueuedJobs();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetEnqueuedJobs<TestJob>();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetEnqueuedJobs<TestJob>(x => x.Job.Method.Name == "ExecuteAsync");
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetEnqueuedJobs<TestJob>(x => x.Job.Method.Name == "Run");
             result.Should().HaveCount(0);
@@ -94,13 +102,16 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
                     new("test1", dto)
                 }));
             var result = GetJobManager().GetProcessingJobs();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetProcessingJobs<TestJob>();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetProcessingJobs<TestJob>(x => x.Job.Method.Name == "ExecuteAsync");
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetProcessingJobs<TestJob>(x => x.Job.Method.Name == "Run");
             result.Should().HaveCount(0);
@@ -116,13 +127,16 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
                     new("test1", dto)
                 }));
             var result = GetJobManager().GetFailedJobs();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetFailedJobs<TestJob>();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetFailedJobs<TestJob>(x => x.Job.Method.Name == "ExecuteAsync");
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetFailedJobs<TestJob>(x => x.Job.Method.Name == "Run");
             result.Should().HaveCount(0);
@@ -139,13 +153,16 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
                     new("test1", dto)
                 }));
             var result = GetJobManager().GetFetchedJobs();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetFetchedJobs<TestJob>();
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetFetchedJobs<TestJob>(x => x.Job.Method.Name == "ExecuteAsync");
-            result.Should().HaveCount(1).And.Contain(dto);
+            result.Should().HaveCount(1);
+            result.Should().Contain(dto);
 
             result = GetJobManager().GetFetchedJobs<TestJob>(x => x.Job.Method.Name == "Run");
             result.Should().HaveCount(0);

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/JobTest.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/JobTest.cs
@@ -21,16 +21,14 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
         public void AsyncJobWillBeCancelledAfterTimeout()
         {
             var job = new TestJobTimeoutAsync(_logger);
-            job.Invoking(async x => await x.ExecuteAsync(new CancellationToken(true))).Should()
-                .ThrowAsync<OperationCanceledException>();
+            Assert.CatchAsync<OperationCanceledException>(async () => await job.ExecuteAsync(new CancellationToken(true)));
         }
 
         [Test]
         public void AsyncJobThrowsException()
         {
             var job = new JobFailsJob(_logger);
-            job.Invoking(async x => await x.ExecuteAsync(new CancellationToken(true))).Should()
-                .ThrowAsync<NotSupportedException>();
+            Assert.ThrowsAsync<NotSupportedException>(async () => await job.ExecuteAsync(new CancellationToken(true)));
         }
 
         [Test]
@@ -47,8 +45,7 @@ namespace PiBox.Plugins.Jobs.Hangfire.Tests
         {
             var param = "Test";
             var job = new ParameterizedAsyncJobTest(_logger);
-            job.Invoking(async x => await x.ExecuteAsync(param, new CancellationToken(true))).Should()
-                .ThrowAsync<OperationCanceledException>();
+            Assert.DoesNotThrowAsync(async () => await job.ExecuteAsync(param, new CancellationToken(true)));
         }
     }
 }

--- a/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/ParameterizedAsyncJobTest.cs
+++ b/PiBox.Plugins/Jobs/Hangfire/test/PiBox.Plugins.Jobs.Hangfire.Tests/ParameterizedAsyncJobTest.cs
@@ -3,18 +3,8 @@ using PiBox.Plugins.Jobs.Hangfire.Job;
 
 namespace PiBox.Plugins.Jobs.Hangfire.Tests
 {
-    public class ParameterizedAsyncJobTest : ParameterizedAsyncJob<string>
+    public class ParameterizedAsyncJobTest(ILogger logger) : ParameterizedAsyncJob<string>(logger)
     {
-        public ParameterizedAsyncJobTest(ILogger logger) : base(logger)
-        {
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            Console.WriteLine();
-            base.Dispose(disposing);
-        }
-
         protected override Task<object> ExecuteJobAsync(string value, CancellationToken cancellationToken)
         {
             Logger.LogInformation("Run {Value}", value);

--- a/PiBox.Plugins/Management/Unleash/test/PiBox.Plugins.Management.Unleash.Tests/UnleashPluginTests.cs
+++ b/PiBox.Plugins/Management/Unleash/test/PiBox.Plugins.Management.Unleash.Tests/UnleashPluginTests.cs
@@ -52,7 +52,7 @@ namespace PiBox.Plugins.Management.Unleash.Tests
             var settings = unleash.GetInaccessibleValue<UnleashSettings>("settings");
             settings.Should().NotBeNull();
             settings.AppName.Should().Be(GetUnleashConfiguration.AppName);
-            settings.UnleashApi.Should().Be(GetUnleashConfiguration.ApiUri);
+            settings.UnleashApi.Should().Be(new Uri(GetUnleashConfiguration.ApiUri));
             settings.CustomHttpHeaders.Should().ContainValue(GetUnleashConfiguration.ApiToken);
             settings.ProjectId.Should().Be(GetUnleashConfiguration.ProjectId);
             settings.InstanceTag.Should().Be(GetUnleashConfiguration.InstanceTag);

--- a/PiBox.Plugins/Persistence/Abstractions/test/PiBox.Plugins.Persistence.Abstractions.Tests/QueryOptionsTest.cs
+++ b/PiBox.Plugins/Persistence/Abstractions/test/PiBox.Plugins.Persistence.Abstractions.Tests/QueryOptionsTest.cs
@@ -124,12 +124,10 @@ namespace PiBox.Plugins.Persistence.Abstractions.Tests
         {
             var queryOptions = new QueryOptions<BaseTestEntity>();
             queryOptions.Invoking(x => x.WithFilter("NotExistingProp eq 123"))
-                .Should().Throw<QueryOptionsException>()
-                .WithMessage("Unable to perform operation 'NotExistingProp'");
+                .Should().Throw<QueryOptionsException>("Unable to perform operation 'NotExistingProp'");
 
             queryOptions.Invoking(x => x.WithOrderBy("NotExistingProp asc"))
-                .Should().Throw<QueryOptionsException>()
-                .WithMessage("Instance property 'NotExistingProp' is not defined for type 'PiBox.Testing.Models.BaseTestEntity' (Parameter 'propertyName')");
+                .Should().Throw<QueryOptionsException>("Instance property 'NotExistingProp' is not defined for type 'PiBox.Testing.Models.BaseTestEntity' (Parameter 'propertyName')");
         }
     }
 }

--- a/PiBox.Plugins/Persistence/EntityFramework/test/PiBox.Plugins.Persistence.EntityFramework.Tests/EntityFrameworkPluginTests.cs
+++ b/PiBox.Plugins/Persistence/EntityFramework/test/PiBox.Plugins.Persistence.EntityFramework.Tests/EntityFrameworkPluginTests.cs
@@ -82,7 +82,6 @@ namespace PiBox.Plugins.Persistence.EntityFramework.Tests
             opts.EnrichWithIDbCommand!(activity, command);
 
             var dbNameTag = activity.Tags.Single(x => x.Key == "db.name");
-            dbNameTag.Should().NotBeNull();
             dbNameTag.Value.Should().Be(command.CommandType + " main");
             activity.DisplayName.Should().Be(command.CommandType + " main");
         }

--- a/PiBox.Plugins/Persistence/S3/test/PiBox.Plugins.Persistence.S3.Tests/S3PluginTests.cs
+++ b/PiBox.Plugins/Persistence/S3/test/PiBox.Plugins.Persistence.S3.Tests/S3PluginTests.cs
@@ -93,7 +93,8 @@ namespace PiBox.Plugins.Persistence.S3.Tests
             var options = uriHealthCheck.GetInaccessibleValue<UriHealthCheckOptions>("_options");
             options.Should().NotBeNull();
             var uriOptions = options.GetInaccessibleValue<List<UriOptions>>("UrisOptions");
-            uriOptions.Should().NotBeNull().And.HaveCount(1);
+            uriOptions.Should().NotBeNull();
+            uriOptions.Should().HaveCount(1);
             var uriOption = uriOptions.Single();
             uriOption.Uri.Authority.Should().Be(_configuration.Endpoint);
             uriOption.Uri.AbsolutePath.Should().Be("/" + _configuration.HealthCheckPath.TrimStart('/'));

--- a/PiBox.Testing/NUnit/src/PiBox.Testing/Assertions/DbAssertions.cs
+++ b/PiBox.Testing/NUnit/src/PiBox.Testing/Assertions/DbAssertions.cs
@@ -120,7 +120,7 @@ namespace PiBox.Testing.Assertions
             {
                 var dict = expected[i];
                 var seedData = list[i];
-                dict.Should().BeEquivalentTo(seedData, $"{typeof(T).Name} has an invalid data entry");
+                dict.Should().BeEquivalentTo(seedData, new KvpStringObjectComparer(), $"{typeof(T).Name} has an invalid data entry");
             }
         }
     }

--- a/PiBox.Testing/NUnit/src/PiBox.Testing/PiBox.Testing.csproj
+++ b/PiBox.Testing/NUnit/src/PiBox.Testing/PiBox.Testing.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
@@ -20,6 +19,7 @@
     </PackageReference>
     <PackageReference Include="NaughtyStrings.Bogus" />
     <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers"/>
     <PackageReference Include="Allure.NUnit" />
     <PackageReference Include="Chronos.Net" />
   </ItemGroup>

--- a/PiBox.Testing/NUnit/src/PiBox.Testing/Shims/FluentAssertionsAdapter.cs
+++ b/PiBox.Testing/NUnit/src/PiBox.Testing/Shims/FluentAssertionsAdapter.cs
@@ -1,0 +1,432 @@
+using System.Collections.Concurrent;
+using NUnit.Framework;
+using PiBox.Testing;
+using PiBox.Testing.Utils;
+
+// ReSharper disable once CheckNamespace
+namespace FluentAssertions
+{
+    public static class FluentAssertionsCommonExtensions
+    {
+        public const string NUnitObsolescenceMssage = "Use NUnit 4.x Assert methods instead.";
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static T As<T>(this object obj) where T : class =>
+            obj as T ?? throw new AssertionException("object is not of type expected");
+    }
+
+    public static class FluentAssertionsReferenceTypeExtensions
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableEnumerable<T> Should<T>(this IEnumerable<T> enumerable) => new(enumerable);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableKeyValueObjects<TKey, TValue> Should<TKey, TValue>(this Dictionary<TKey, TValue> dict) =>
+            new(dict);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableKeyValueObjects<TKey, TValue> Should<TKey, TValue>(this IDictionary<TKey, TValue> dict) =>
+            new(dict);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableKeyValueObjects<TKey, TValue> Should<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> dict) =>
+            new(dict);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableKeyValueObjects<TKey, TValue> Should<TKey, TValue>(
+            this IReadOnlyDictionary<TKey, TValue> dict) => new(dict);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableReferenceType<object> Should(this object obj) => new(obj);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableString Should(this string obj) => new(obj);
+    }
+
+    public static class FluentAssertionsValueTypeExtensions
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableValueType<T> Should<T>(this T val) where T : struct => new(val);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableGuid Should(this Guid guid) => new(guid);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableBool Should(this bool boolean) => new(boolean);
+    }
+
+    public static class FluentAssertionsMetricMeasurementExtensions
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static TestableListMetricMeasurement Should(this List<MetricMeasurement> val) => new(val);
+    }
+
+    public abstract class TestableBase<T>
+    {
+        protected abstract T Should { get; }
+
+        public Converted<TTarget> BeOfType<TTarget>()
+        {
+            Assert.That(Should, Is.TypeOf<TTarget>());
+            return new Converted<TTarget>((TTarget)(object)Should);
+        }
+
+        public void BeOfType<TTarget>(string message) => Assert.That(Should, Is.TypeOf<TTarget>(), message);
+        public void BeOfType(Type type) => Assert.That(Should, Is.TypeOf(type));
+
+        public void BeOfType(Type type, string message) =>
+            Assert.That(Should, Is.TypeOf(type), message);
+
+        public class Converted<TTarget>(TTarget subject)
+        {
+            public TTarget Subject { get; } = subject;
+        }
+    }
+
+    public abstract class TestableReferenceTypeBase<T> : TestableBase<T> where T : class
+    {
+        public void Be(T o) => Assert.That(Should, Is.EqualTo(o));
+        public void Be(T o, string message) => Assert.That(Should, Is.EqualTo(o), message);
+
+        public void NotBe(T o) => Assert.That(Should, Is.Not.EqualTo(o));
+        public void NotBe(T o, string message) => Assert.That(Should, Is.Not.EqualTo(o), message);
+
+        public void NotBeNull() => Assert.That(Should, Is.Not.Null);
+        public void NotBeNull(string message) => Assert.That(Should, Is.Not.Null, message);
+
+        public void BeNull() => Assert.That(Should, Is.Null);
+        public void BeNull(string message) => Assert.That(Should, Is.Null, message);
+    }
+
+    public abstract class TestableValueTypeBase<T> : TestableBase<T> where T : struct
+    {
+        public void Be(T o) => Assert.That(Should, Is.EqualTo(o));
+        public void Be(T o, string message) => Assert.That(Should, Is.EqualTo(o), message);
+
+        public void NotBe(T o) => Assert.That(Should, Is.Not.EqualTo(o));
+        public void NotBe(T o, string message) => Assert.That(Should, Is.Not.EqualTo(o), message);
+    }
+
+    public class TestableGuid(Guid should) : TestableValueTypeBase<Guid>
+    {
+        protected override Guid Should { get; } = should;
+
+        public void NotBe(Guid guid) => Assert.That(Should, Is.Not.EqualTo(guid));
+        public void NotBeEmpty() => Assert.That(Should, Is.Not.EqualTo(Guid.Empty));
+    }
+
+    public class TestableBool(bool should) : TestableValueTypeBase<bool>
+    {
+        protected override bool Should { get; } = should;
+
+        public void BeFalse() => Assert.That(Should, Is.False);
+        public void BeFalse(string message) => Assert.That(Should, Is.False, message);
+        public void BeTrue() => Assert.That(Should, Is.True);
+        public void BeTrue(string message) => Assert.That(Should, Is.True, message);
+    }
+
+    public class TestableValueType<T>(T should) : TestableValueTypeBase<T> where T : struct
+    {
+        protected override T Should { get; } = should;
+    }
+
+    public class TestableKeyValueObjects<TKey, TValue>(object should)
+        : TestableEnumerable<KeyValuePair<TKey, TValue>>((IEnumerable<KeyValuePair<TKey, TValue>>)should)
+    {
+        public void ContainKey(TKey key) => Assert.That(Should, Does.ContainKey(key));
+        public void ContainKey(TKey key, string message) => Assert.That(Should, Does.ContainKey(key), message);
+
+        public void NotContainKey(TKey key) => Assert.That(Should, Does.Not.ContainKey(key));
+        public void NotContainKey(TKey key, string message) => Assert.That(Should, Does.Not.ContainKey(key), message);
+
+        public void ContainValue(TValue value) => Assert.That(Should, Does.ContainValue(value));
+        public void ContainValue(TValue value, string message) => Assert.That(Should, Does.ContainValue(value), message);
+
+        public void NotContainValue(TValue value) => Assert.That(Should, Does.Not.ContainValue(value));
+        public void NotContainValue(TValue value, string message) => Assert.That(Should, Does.Not.ContainValue(value), message);
+    }
+
+    public class TestableEnumerable<T>(IEnumerable<T> should) : TestableReferenceTypeBase<IEnumerable<T>>
+    {
+        protected override IEnumerable<T> Should { get; } = should;
+
+        public void NotBeEmpty() => Assert.That(Should.Any(), Is.True);
+        public void NotBeEmpty(string message) => Assert.That(Should.Any(), Is.True, message);
+
+        public void BeEmpty() => Assert.That(Should.Any(), Is.False);
+        public void BeEmpty(string message) => Assert.That(Should.Any(), Is.False, message);
+
+        public void BeNullOrEmpty() => Assert.That(Should.Count(), Should is null ? Is.Null : Is.EqualTo(0));
+
+        public void BeNullOrEmpty(string message) =>
+            Assert.That(Should.Count(), Should is null ? Is.Null : Is.EqualTo(0), message);
+
+        public void HaveCount(int count) => Assert.That(Should.Count(), Is.EqualTo(count));
+        public void HaveCount(int count, string message) => Assert.That(Should.Count(), Is.EqualTo(count), message);
+        public void HaveCountGreaterThan(int count) => Assert.That(Should.Count(), Is.GreaterThan(count));
+        public void HaveCountGreaterThan(int count, string message) => Assert.That(Should.Count(), Is.GreaterThan(count), message);
+        public void HaveCountGreaterOrEqualTo(int count) => Assert.That(Should.Count(), Is.GreaterThanOrEqualTo(count));
+        public void HaveCountGreaterOrEqualTo(int count, string message) => Assert.That(Should.Count(), Is.GreaterThanOrEqualTo(count), message);
+
+#pragma warning disable NUnit2007
+        public void BeEquivalentTo(IEnumerable<T> expectation, IEqualityComparer<T> comparer) =>
+            Assert.That(true, Is.EqualTo(TestUtils.CompareSequences(Should, expectation, comparer)),
+                "Sequences are not equivalent");
+
+        public void BeEquivalentTo(IEnumerable<T> expectation, IEqualityComparer<T> comparer, string message) =>
+            Assert.That(true, Is.EqualTo(TestUtils.CompareSequences(Should, expectation, comparer)), message);
+#pragma warning restore NUnit2007
+
+        public void NotBeNullOrEmpty()
+        {
+            if (Should != null)
+                Assert.That(Should.Count(), Is.GreaterThan(0));
+        }
+
+        public void Satisfy(params Func<T, bool>[] func)
+        {
+            var list = Should.ToList();
+
+            Assert.That(list, Has.Count.EqualTo(func.Length));
+
+            var result = new bool[list.Count];
+
+            foreach (var (f, i) in func.Select((x, i) => (x, i)))
+                foreach (var s in list)
+                    result[i] |= f(s);
+
+            // ReSharper disable once ReplaceWithSingleCallToAny
+            Assert.That(result.Where(r => !r).Any(), Is.False);
+        }
+
+        public void ContainSingle(Func<T, bool> predicate) =>
+            Assert.That(Should.Where(predicate).SingleOrDefault(), Is.Not.Default);
+        public void ContainSingle(Func<T, bool> predicate, string message) =>
+            Assert.That(Should.Where(predicate).SingleOrDefault(), Is.Not.Default, message);
+
+        // ReSharper disable once ReplaceWithSingleCallToAny
+        public void AllSatisfy(Func<T, bool> func) => Assert.That(Should.Where(s => !func(s)).Any(), Is.False);
+
+        public void Contain(T content) => Assert.That(Should, Does.Contain(content));
+        public void Contain(T content, string messages) => Assert.That(Should, Does.Contain(content), messages);
+        public void Contain(Func<T, bool> contentExpr) => Assert.That(Should.Any(contentExpr), Is.True);
+        public void Contain(Func<T, bool> contentExpr, string message) =>
+            Assert.That(Should.Any(contentExpr), Is.True, message);
+        public void Contain(IEnumerable<T> containList) => Assert.That(Should, Is.SupersetOf(containList));
+        public void Contain(IEnumerable<T> containList, string message) =>
+            Assert.That(Should, Is.SupersetOf(containList), message);
+
+        public void NotContain(T content) => Assert.That(Should, Does.Not.Contain(content));
+        public void NotContain(T content, string messages) => Assert.That(Should, Does.Not.Contain(content), messages);
+        public void NotContain(Func<T, bool> contentExpr) => Assert.That(Should.Any(contentExpr), Is.False);
+
+        public void NotContain(Func<T, bool> contentExpr, string message) =>
+            Assert.That(Should.Any(contentExpr), Is.False, message);
+
+        public void Equal(IEnumerable<T> expected)
+        {
+            var listShould = Should.ToList();
+            var listExpected = expected.ToList();
+
+            Assert.That(listShould, Has.Count.EqualTo(listExpected.Count));
+
+            for (var i = 0; i < listShould.Count; i++)
+            {
+                Assert.That(listShould[i], Is.EqualTo(listExpected[i]));
+            }
+        }
+        public void Equal(IEnumerable<T> expected, string message)
+        {
+            var listShould = Should.ToList();
+            var listExpected = expected.ToList();
+
+            Assert.That(listShould, Has.Count.EqualTo(listExpected.Count), message);
+
+            for (var i = 0; i < listShould.Count; i++)
+            {
+                Assert.That(listShould[i], Is.EqualTo(listExpected[i]), message);
+            }
+        }
+    }
+
+    public class TestableString(string should) : TestableReferenceType<string>(should)
+    {
+        public void BeEmpty() => Assert.That(Should, Is.Empty);
+        public void BeEmpty(string message) => Assert.That(Should, Is.Empty, message);
+
+        public void NotBeEmpty() => Assert.That(Should, Is.Not.Empty);
+        public void NotBeEmpty(string message) => Assert.That(Should, Is.Not.Empty, message);
+
+        public void Contain(string substr) => Assert.That(Should, Does.Contain(substr));
+        public void Contain(string substr, string message) => Assert.That(Should, Does.Contain(substr), message);
+
+        public void NotContain(string substr) => Assert.That(Should, Does.Not.Contain(substr));
+        public void NotContain(string substr, string message) => Assert.That(Should, Does.Not.Contain(substr), message);
+
+        public void StartWith(string substr) => Assert.That(Should, Does.StartWith(substr));
+        public void StartWith(string substr, string message) => Assert.That(Should, Does.StartWith(substr), message);
+
+        public void EndWith(string substr) => Assert.That(Should, Does.EndWith(substr));
+        public void EndWith(string substr, string message) => Assert.That(Should, Does.EndWith(substr), message);
+
+        public void Match(string match) => Assert.That(Should, Does.Match(match));
+        public void Match(string match, string message) => Assert.That(Should, Does.Match(match), message);
+    }
+
+    public class TestableReferenceType<T>(T should) : TestableReferenceTypeBase<T> where T : class
+    {
+        protected override T Should { get; } = should;
+
+        public void BeAssignableTo<TAssignable>() => Assert.That(Should, Is.AssignableTo<TAssignable>());
+
+        public void BeSameAs(T expectation) => Assert.That(Should, Is.SameAs(expectation));
+        public void BeSameAs(T expectation, string message) => Assert.That(Should, Is.SameAs(expectation), message);
+        public void NotBeSameAs(T expectation) => Assert.That(Should, Is.Not.SameAs(expectation));
+        public void NotBeSameAs(T expectation, string message) => Assert.That(Should, Is.Not.SameAs(expectation), message);
+
+        public void BeEquivalentTo<R>(IEnumerable<R> expectation) => Assert.That(Should, Is.EquivalentTo(expectation));
+        public void BeEquivalentTo<R>(IEnumerable<R> expectation, string message) => Assert.That(Should, Is.EquivalentTo(expectation), message);
+
+        public void NotBeNullOrEmpty() => Assert.That(Should, Is.Not.Null.And.Not.Empty);
+
+        public void Match(Func<T, bool> predicate) => Assert.That(predicate(Should), Is.True);
+        public void Match(Func<T, bool> predicate, string message) => Assert.That(predicate(Should), Is.True, message);
+    }
+
+    public static class FluentAssertionsThrowExtensions
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static FluentAssertionsFuncSyncThrowHelper<T, R> Invoking<T, R>(this T obj, Func<T, R> predicate) =>
+            new(obj, predicate);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static FluentAssertionsAsyncThrowHelper<T, Task> Invoking<T>(this T obj, Func<T, Task> predicate) =>
+            new(obj, predicate);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static FluentAssertionsAsyncThrowHelper<T, Task<R>> Invoking<T, R>(this T obj,
+            Func<T, Task<R>> predicate) =>
+            new(obj, predicate);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static FluentAssertionsActionSyncThrowHelper<T> Invoking<T>(this T obj, Action<T> action) =>
+            new(obj, action);
+
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public static FluentAssertionsActionNoParameterThrowHelper Should(this Action action) => new(action);
+    }
+
+    public class FluentAssertionsActionNoParameterThrowHelper(Action action)
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public FluentAssertionsActionNoParameterThrowHelper Should() => this;
+
+        public void NotThrow() => Assert.DoesNotThrow(() => action());
+        public void NotThrow(string message) => Assert.DoesNotThrow(() => action(), message);
+
+        public TException Throw<TException>() where TException : Exception => Assert.Catch<TException>(() => action());
+
+        public TException Throw<TException>(string message) where TException : Exception =>
+            Assert.Catch<TException>(() => action(), message);
+    }
+
+    public class FluentAssertionsActionSyncThrowHelper<T>(T obj, Action<T> action)
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public FluentAssertionsActionSyncThrowHelper<T> Should() => this;
+
+        public void NotThrow() => Assert.DoesNotThrow(() => action(obj));
+        public void NotThrow(string message) => Assert.DoesNotThrow(() => action(obj), message);
+
+        public TException Throw<TException>() where TException : Exception =>
+            Assert.Catch<TException>(() => action(obj));
+
+        public TException Throw<TException>(string message) where TException : Exception =>
+            Assert.Catch<TException>(() => action(obj), message);
+    }
+
+    public class FluentAssertionsFuncSyncThrowHelper<T, R>(T obj, Func<T, R> predicate)
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public FluentAssertionsFuncSyncThrowHelper<T, R> Should() => this;
+
+        public Task NotThrowAsync()
+        {
+            Assert.DoesNotThrowAsync(() => Task.FromResult(predicate(obj)));
+            return Task.CompletedTask;
+        }
+
+        public Task NotThrowAsync(string message)
+        {
+            Assert.DoesNotThrowAsync(() => Task.FromResult(predicate(obj)), message);
+            return Task.CompletedTask;
+        }
+
+        public Task<TException> ThrowAsync<TException>() where TException : Exception =>
+            Task.FromResult(Assert.CatchAsync<TException>(() => Task.FromResult(predicate(obj))));
+
+        public void NotThrow() => Assert.DoesNotThrow(() => predicate(obj));
+        public void NotThrow(string message) => Assert.DoesNotThrow(() => predicate(obj), message);
+
+        public TException Throw<TException>() where TException : Exception =>
+            Assert.Catch<TException>(() => predicate(obj));
+
+        public TException Throw<TException>(string message) where TException : Exception =>
+            Assert.Catch<TException>(() => predicate(obj), message);
+    }
+
+    public class FluentAssertionsAsyncThrowHelper<T, R>(T obj, Func<T, R> action) where R : Task
+    {
+        [Obsolete(FluentAssertionsCommonExtensions.NUnitObsolescenceMssage)]
+        public FluentAssertionsAsyncThrowHelper<T, R> Should() => this;
+
+        public Task NotThrowAsync()
+        {
+            Assert.DoesNotThrowAsync(() => action(obj));
+            return Task.CompletedTask;
+        }
+
+        public Task NotThrowAsync(string message)
+        {
+            Assert.DoesNotThrowAsync(() => action(obj), message);
+            return Task.CompletedTask;
+        }
+
+        public Task<TException> ThrowAsync<TException>() where TException : Exception =>
+            Task.FromResult(Assert.CatchAsync<TException>(() => action(obj)));
+
+        public Task<TException> ThrowAsync<TException>(string message) where TException : Exception =>
+            Task.FromResult(Assert.CatchAsync<TException>(() => action(obj), message));
+    }
+
+    public class TestableListMetricMeasurement(List<MetricMeasurement> val) : TestableEnumerable<MetricMeasurement>(val)
+    {
+        public void ContainsMetric(long value) =>
+            Assert.That(Should.Any(tuple => tuple.Measurement == value), Is.True);
+
+        public void ContainsMetric(long value, string message) =>
+            Assert.That(Should.Any(tuple => tuple.Measurement == value), Is.True, message);
+
+        public void ContainsMetric(long value, string expectedTagKey, string expectedTagValue) =>
+            Assert.That(Should.Any(tuple =>
+                    tuple.Measurement == value
+                    && tuple.Tags.Any(
+                        x => x.Key == expectedTagKey
+                             && x.Value == expectedTagValue)),
+                Is.True);
+
+        public void ContainsMetric(long value, string expectedTagKey, string expectedTagValue, string message) =>
+            Assert.That(Should.Any(tuple =>
+                    tuple.Measurement == value
+                    && tuple.Tags.Any(
+                        x => x.Key == expectedTagKey
+                             && x.Value == expectedTagValue)),
+                Is.True, message);
+    }
+
+    public class KvpStringObjectComparer : IEqualityComparer<KeyValuePair<string, object>>
+    {
+        public bool Equals(KeyValuePair<string, object> x, KeyValuePair<string, object> y) => x.Key == y.Key && Equals(x.Value, y.Value);
+        public int GetHashCode(KeyValuePair<string, object> obj) => HashCode.Combine(obj.Key, obj.Value);
+    }
+}

--- a/PiBox.Testing/NUnit/src/PiBox.Testing/TestMetricsCollector.cs
+++ b/PiBox.Testing/NUnit/src/PiBox.Testing/TestMetricsCollector.cs
@@ -1,7 +1,4 @@
 using System.Diagnostics.Metrics;
-using FluentAssertions;
-using FluentAssertions.Collections;
-using FluentAssertions.Execution;
 
 namespace PiBox.Testing
 {
@@ -54,67 +51,5 @@ namespace PiBox.Testing
         {
             _myMeterListener?.Dispose();
         }
-    }
-
-    public static class TestMetricsCollectorExtensions
-    {
-        public static TestMetricsCollectorAssertions Should(this List<MetricMeasurement> instance)
-        {
-            return new(instance);
-        }
-    }
-
-    public class TestMetricsCollectorAssertions :
-        GenericCollectionAssertions<MetricMeasurement>
-
-    {
-        public TestMetricsCollectorAssertions(List<MetricMeasurement> instance)
-            : base(instance)
-        {
-        }
-
-        protected override string Identifier => "collection";
-        // ReSharper disable once UnusedMethodReturnValue.Global
-        public AndConstraint<TestMetricsCollectorAssertions> ContainsMetric(
-            long value, string expectedTagKey, string expectedTagValue, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .Given(() => Subject)
-                .ForCondition(c => c.Any(tuple => tuple.Measurement == value && tuple.Tags
-                    .Any(x => x.Key == expectedTagKey && x.Value == expectedTagValue)))
-                .FailWith("Expected {context:measurements} to contain item with value {0} tagkey {1} tagValue {2}{reason}, but found {3}.",
-                    _ => value, _ => expectedTagKey, _ => expectedTagValue, measurements => System.Text.Json.JsonSerializer.Serialize(measurements));
-
-            return new AndConstraint<TestMetricsCollectorAssertions>(this);
-        }
-
-        public AndConstraint<TestMetricsCollectorAssertions> ContainsMetric(
-            long value, KeyValuePair<string, string>[] tags, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .Given(() => Subject)
-                .ForCondition(c => c.Any(tuple => tuple.Measurement == value && tuple.Tags
-                    .SequenceEqual(tags)))
-                .FailWith("Expected {context:measurements} to contain item with value {0} tags {1}{reason}, but found {2}.",
-                    _ => value, tags => System.Text.Json.JsonSerializer.Serialize(tags), measurements => System.Text.Json.JsonSerializer.Serialize(measurements));
-
-            return new AndConstraint<TestMetricsCollectorAssertions>(this);
-        }
-
-        public AndConstraint<TestMetricsCollectorAssertions> ContainsMetric(
-            long value, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .Given(() => Subject)
-                .ForCondition(c => c.Any(tuple => tuple.Measurement == value))
-                .FailWith("Expected {context:measurements} to contain item with value {0}{reason}, but found {1}.",
-                    _ => value, measurements => System.Text.Json.JsonSerializer.Serialize(measurements));
-
-            return new AndConstraint<TestMetricsCollectorAssertions>(this);
-        }
-        // ReSharper enable once UnusedMethodReturnValue.Global
     }
 }

--- a/PiBox.Testing/NUnit/src/PiBox.Testing/Utils/TestHelpers.cs
+++ b/PiBox.Testing/NUnit/src/PiBox.Testing/Utils/TestHelpers.cs
@@ -1,0 +1,20 @@
+namespace PiBox.Testing.Utils;
+
+#nullable enable
+
+public static class TestUtils
+{
+    public static bool CompareSequences<T>(IEnumerable<T>? first, IEnumerable<T>? second, IEqualityComparer<T>? comparer)
+    {
+        if (first is null && second is null)
+            return true;
+
+        if ((first is not null && second is null)
+            || (first is null && second is not null))
+            return false;
+
+        return first!.SequenceEqual(second!, comparer);
+    }
+}
+
+#nullable restore

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ We are using these frameworks for unit testing
 
 * AutoBogus
 * Bogus
-* FluentAssertions
 * Microsoft.NET.Test.Sdk
 * NaughtyStrings.Bogus
 * NSubstitute

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "1.2",
   "gitCommitIdShortAutoMinimum": 7,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
FluentAssertions version 8 is not free for commercial use anymore. So we are getting rid of it.